### PR TITLE
Cast everytime key as string.

### DIFF
--- a/src/Mapper/Dbal/StorageReflection/StorageReflection.php
+++ b/src/Mapper/Dbal/StorageReflection/StorageReflection.php
@@ -98,7 +98,7 @@ abstract class StorageReflection implements IStorageReflection
 			if (isset($this->mappings[self::TO_STORAGE][$key][0])) {
 				$newKey = $this->mappings[self::TO_STORAGE][$key][0];
 			} else {
-				$newKey = $this->convertEntityToStorageKey($key);
+				$newKey = $this->convertEntityToStorageKey((string) $key);
 			}
 			if (isset($this->modifiers[$newKey])) {
 				$newKey .= $this->modifiers[$newKey];
@@ -122,7 +122,7 @@ abstract class StorageReflection implements IStorageReflection
 			if (isset($this->mappings[self::TO_ENTITY][$key][0])) {
 				$newKey = $this->mappings[self::TO_ENTITY][$key][0];
 			} else {
-				$newKey = $this->convertStorageToEntityKey($key);
+				$newKey = $this->convertStorageToEntityKey((string) $key);
 			}
 			if (isset($this->mappings[self::TO_ENTITY][$key][1])) {
 				$converter = $this->mappings[self::TO_ENTITY][$key][1];


### PR DESCRIPTION
I have some columns in my tables, where the column name is only **int**. Yes I know it´s bad idea but this tables was not created by me. Then if I want read from this table it everytime show error, which is on picture below.

![obrazek](https://user-images.githubusercontent.com/3403705/37910931-029eed60-310f-11e8-9f2d-46dab737530e.png)

![obrazek](https://user-images.githubusercontent.com/3403705/37911139-87e84408-310f-11e8-8736-ce969f0fc4c1.png)
